### PR TITLE
Split out a separate 'uatStage.reportExtents' function

### DIFF
--- a/vars/uatStage.groovy
+++ b/vars/uatStage.groovy
@@ -31,20 +31,36 @@ def call(String gitRepo = "", String branch = "", String artifactName = "app.zip
 		} else {
 			body()
 		}
-		try {
-			//Test Reporting
-			//${folderPath}**/*.junit, ${folderPath}**/junit-reports/*.xml, ${folderPath}**/junitreports/*.xml, ${folderPath}**/test-results/**/*.xml, ${folderPath}**/*junit.xml, 
-			junit allowEmptyResults: true, testResults: "${folderPath}**/testng-results.xml, ${folderPath}**/junitreports/TEST*.xml"
-		} catch (Exception e) {
-			throw e
-		}
-		if (!slack.hasTest()) {
-			currentBuild.result = "UNSTABLE"
-		}
-		extentReportDir = sh(script: "find . -name Extent-Report -type d", returnStdout: true)
-		extentReportDir = extentReportDir.replace("./", "")
-		extentReportHtml = sh(script: "ls ${extentReportDir}", returnStdout: true)
-		publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, keepAll: false, reportDir: "${extentReportDir}", reportFiles: "${extentReportHtml}", reportName: "Extent-Report", reportTitles: ""])
-		slack.uatMessage()
+		reportExtents(folderPath)
 	}
+}
+
+/**
+ * Extent Reports are these fancy HTML test results, with step-by-step information
+ * and pictures and even a pie chart. This method will
+ * <ol>
+ *     <li>run JUnit</li>
+ *     <li>collect all HTML files found in folders called "Extent-Report"</li>
+ *     <li>call 'publishHTML' with these files</li>
+ *     <li>call {@link slack#uatMessage}</li>
+ * </ol>
+ *
+ * @param folderPath common ancestor of wherever the JUnit testResults are placed
+ */
+def reportExtents(String folderPath) {
+	try {
+		//Test Reporting
+		//${folderPath}**/*.junit, ${folderPath}**/junit-reports/*.xml, ${folderPath}**/junitreports/*.xml, ${folderPath}**/test-results/**/*.xml, ${folderPath}**/*junit.xml,
+		junit allowEmptyResults: true, testResults: "${folderPath}**/testng-results.xml, ${folderPath}**/junitreports/TEST*.xml"
+	} catch (Exception e) {
+		throw e
+	}
+	if (!slack.hasTest()) {
+		currentBuild.result = "UNSTABLE"
+	}
+	extentReportDir = sh(script: "find . -name Extent-Report -type d", returnStdout: true)
+	extentReportDir = extentReportDir.replace("./", "")
+	extentReportHtml = sh(script: "ls ${extentReportDir}", returnStdout: true)
+	publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, keepAll: false, reportDir: "${extentReportDir}", reportFiles: "${extentReportHtml}", reportName: "Extent-Report", reportTitles: ""])
+	slack.uatMessage()
 }


### PR DESCRIPTION
Apparently I don't have permission to just merge this in? Ah well. This just creates a new method that can be called from non-uatStage scripts.