### PR TITLE
Default to HTTPS in `publishLink.groovy`

### DIFF
--- a/vars/publishLink.groovy
+++ b/vars/publishLink.groovy
@@ -10,15 +10,18 @@
  * @see injectDeploymentVars#call
  */
 def call(String urlScheme = "https") {
+
+    // First, define a common 'deployment url' where the application can be found.
+    String deploymentURL = "${urlScheme}://${env.DEPLOY_URL}"
+
     // Publish a Rich Text Publishing message - this will appear on the Build Status page.
 	// See https://jenkins.io/doc/pipeline/steps/rich-text-publisher-plugin/ for syntax
 	rtp(
 			nullAction: '1',
 			parserName: 'HTML',
-			stableText: "<a href=\"${urlScheme}://${env.DEPLOY_URL}\">${urlScheme}://${env.DEPLOY_URL}</a>"
+			stableText: "<a href=\"${deploymentURL}\">${deploymentURL}</a>"
 	)
 
     // Publish a plain URL to our Slack integration. That'll handle formatting for us.
-	deploymentURL = "${urlScheme}://${env.DEPLOY_URL}"
 	slack.linkMessage(deploymentURL)
 }


### PR DESCRIPTION
This
1. explains what, exactly, the Jenkins `rtp` command is
2. changes the default url scheme from `http` to `https`

No impact on the other script files.