### PR TITLE
Improved Sloccount error-handling

### DIFF
--- a/vars/prettyNode.groovy
+++ b/vars/prettyNode.groovy
@@ -59,19 +59,25 @@ def call(String nodeName = "", Boolean checkoutCode = true, Boolean onlyPR = tru
 					try {
 						body()
 					} catch(Throwable e) {
-						println "Detected error during custom node execution: ${e.message}"
+						println "Detected error during custom node execution."
 						if (isMultibranch()) {
-							slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
+							try {
+								slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
+							} catch (Throwable ignored) {
+							}
 						}
 						handledError = true
-        				throw e
+						throw e
 					}
 				}
 			}
 		} catch(Throwable e) {
 			println "Detected error in process of running (setup? teardown?) node: ${e.message}"
 			if (isMultibranch() && !handledError) {
-				slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
+				try {
+					slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
+				} catch (Throwable ignored) {
+				}
 			}
 			throw e
 		}

--- a/vars/prettyNode.groovy
+++ b/vars/prettyNode.groovy
@@ -59,6 +59,7 @@ def call(String nodeName = "", Boolean checkoutCode = true, Boolean onlyPR = tru
 					try {
 						body()
 					} catch(Throwable e) {
+						println "Detected error during custom node execution: ${e.message}"
 						if (isMultibranch()) {
 							slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
 						}
@@ -68,10 +69,11 @@ def call(String nodeName = "", Boolean checkoutCode = true, Boolean onlyPR = tru
 				}
 			}
 		} catch(Throwable e) {
+			println "Detected error in process of running (setup? teardown?) node: ${e.message}"
 			if (isMultibranch() && !handledError) {
 				slack.sendSlackError(e, "Unknown failure detected during _*Stage ${env.STAGE_NAME}*_")
 			}
-        	throw e
+			throw e
 		}
 	} else {
 		println "PR Found not building this branch"

--- a/vars/reportQuality.groovy
+++ b/vars/reportQuality.groovy
@@ -63,10 +63,9 @@ def call(Closure<List> preferredToolset = null) {
 		} else {
 			legacy()
 		}
-		if (env.IS_WEB == 'true') {
-			echo 'Downstreams have reported instability caused by running the Sloccount plugin against web projects. Callers may still execute the sloccount command directly at their own risk.'
-		} else {
+		try {
 			sloccountPublish encoding: '', pattern: '**/*cloc.xml'
+		} catch (Throwable t) {
 		}
 	} catch (Exception ex) {
 		// Let us give voice to all errors

--- a/vars/reportQuality.groovy
+++ b/vars/reportQuality.groovy
@@ -63,7 +63,11 @@ def call(Closure<List> preferredToolset = null) {
 		} else {
 			legacy()
 		}
-		sloccountPublish encoding: '', pattern: '**/*cloc.xml'
+		if (env.IS_WEB == 'true') {
+			echo 'Downstreams have reported instability caused by running the Sloccount plugin against web projects. Callers may still execute the sloccount command directly at their own risk.'
+		} else {
+			sloccountPublish encoding: '', pattern: '**/*cloc.xml'
+		}
 	} catch (Exception ex) {
 		// Let us give voice to all errors
 		println "An issue: ${ex.message}"


### PR DESCRIPTION
Our existing logic can provide unhelpful messages if a `reportQuality` tool (like Sloccount) fails to run correctly. With these changes

1. Sloccount reporting is disabled by default on all web projects
2. errors thrown by `slack::sendSlackError` in `prettyNode.groovy` will be suppressed

Note that Jenkins agents can get into a corrupted state when certain kinds of errors are thrown, and thus it isn't safe to assume that subsequent `slack` calls made on a damaged node will always succeed.