### PR TITLE
Report: use `env.QUALITY_SERVICES` as a unique id

### DIFF
--- a/vars/reportQuality.groovy
+++ b/vars/reportQuality.groovy
@@ -134,6 +134,7 @@ void collateIssues(Closure<List> translateToToolset) {
 		recordIssues(
 				aggregatingResults: true,
 				enabledForFailure: true,
+				id: env.QUALITY_SERVICES,
 				tools: toolset
 		)
 	} catch (RuntimeException unexpected) {


### PR DESCRIPTION
This should allow the sort of aggregation you'd expect when the `reportQuality.groovy` script is called more than once. C.f. https://issues.jenkins-ci.org/browse/JENKINS-54027 .

