### PR TITLE
Slack conversation support

### DIFF
--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -72,6 +72,8 @@ private void ensureThreadAnchor() {
 
 		// Local variable representing the response from Slack's API.
 		def slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader
+		// We keep around the original response as a header, so that we can attach emoji.
+		env.SLACK_THREAD_HEADER = slackResponse
 		env.SLACK_THREAD_ID = slackResponse.threadId
 	}
 }
@@ -630,6 +632,9 @@ def sendSlackError(Exception e, String message) {
 		// 2. Send the logs to Slack.
 		ensureThreadAnchor()
 
+		// Attach a warning emoji to the thread anchor
+		env.SLACK_THREAD_HEADER.addReaction("warning")
+
 		// Local variable representing the response from Slack's API.
 		//noinspection GroovyUnusedAssignment
 		def slackResponse = null
@@ -640,9 +645,9 @@ def sendSlackError(Exception e, String message) {
 		slackSend color: 'danger', channel: slackThread, message:"```${logsString}```"
 
 		if (!errorMessage.contains("script returned exit code 1")) {
-			// Attach a warning emoji to the existing message...
+			// Attach a no_entry_sign emoji to the existing message...
 			echo "Attaching a response to the header message..."
-			slackResponse.addReaction("warning")
+			slackResponse.addReaction("no_entry_sign")
 			// ...and send a stacktrace to the DevOps monitoring channel
 			echo "...and making two additional notes elsewhere."
 			slackResponse = slackSend color: 'danger', channel: "jenkins_notifications", message: slackHeader() + "${e}"

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -692,7 +692,31 @@ def sendMessageWithLogs(String message) {
 }
 
 /**
- * Send a 'Build Complete!' Slack message including
+ * Send a list of commit messages to Slack.
+ * <p>
+ *     Above the list we add a simple header with
+ *     <ul>
+ *         <li>{@link slack#jobName Job name}</li>
+ *         <li>Build number</li>
+ *         <li>Link to VCS changelog</li>
+ *     </ul>
+ *     The commits themselves are assembled by {@link slack#getCommitLog}.
+ * </p>
+ *
+ * @see slack#buildMessage
+ * @see slack#linkMessage
+ */
+void sendCommitLogMessage() {
+	def jobName = jobName()
+
+	ensureThreadAnchor()
+
+	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
+	slackSend color: 'good', channel: slackThread, message: commitLogHeader + getCommitLog()
+}
+
+/**
+ * Send up to two 'Build Complete!' Slack messages including
  * <ul>
  *     <li>{@link slack#nodeDescription Standard node description}</li>
  *     <li>{@link slack#getArtifacts List of artifacts on current build}</li>
@@ -701,6 +725,9 @@ def sendMessageWithLogs(String message) {
  *     <li>Link to VCS changelog</li>
  *     <li>{@link slack#getCommitLog List of commit messages}</li>
  * </ul>
+ * <p>
+ *     We delegate the last four of those to {@link slack#sendCommitLogMessage}.
+ * </p>
  *
  * @return nothing
  * @see slack#linkMessage
@@ -708,20 +735,18 @@ def sendMessageWithLogs(String message) {
  * @see slack#uatMessage
  */
 def buildMessage() {
-	def jobName = jobName()
 	def node = nodeDescription()
 	def slackArtifacts = getArtifacts()
 
 	ensureThreadAnchor()
 
 	slackSend color: 'good', channel: slackThread, message: node + slackArtifacts
-	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-	slackSend color: 'good', channel: slackThread, message: commitLogHeader + getCommitLog()
+	sendCommitLogMessage()
 }
 
 
 /**
- * Send a 'Website Deployed!' Slack message including
+ * Send up to two 'Website Deployed!' Slack messages including
  * <ul>
  *     <li>{@link slack#nodeDescription Standard node description}</li>
  *     <li>{@link publishLink#call Link to the deployment}</li>
@@ -730,6 +755,9 @@ def buildMessage() {
  *     <li>Link to VCS changelog</li>
  *     <li>{@link slack#getCommitLog List of commit messages}</li>
  * </ul>
+ * <p>
+ *     We delegate the last four of those to {@link slack#sendCommitLogMessage}.
+ * </p>
  *
  * @param inURL http or https url for the deployed website
  * @return nothing
@@ -738,15 +766,13 @@ def buildMessage() {
  * @see slack#uatMessage
  */
 def linkMessage(String inURL) {
-	def jobName = jobName()
 	def header = nodeDescription()
 	def slackArtifacts = "${inURL}\n"
 
 	ensureThreadAnchor()
 
 	slackSend color: 'good', channel: slackThread, message: header + slackArtifacts
-	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-	slackSend color: 'good', channel: slackThread, message: commitLogHeader + getCommitLog()
+	sendCommitLogMessage()
 }
 
 /**

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -19,11 +19,11 @@ import hudson.tasks.junit.TestResultAction
  * @return either env.SLACK_CHANNEL (if present) or "jenkins_notifications"
  */
 def getSlackChannel() {
-    if (env.SLACK_CHANNEL) {
-        return env.SLACK_CHANNEL
-    } else {
-        return "jenkins_notifications"
-    }
+	if (env.SLACK_CHANNEL) {
+		return env.SLACK_CHANNEL
+	} else {
+		return "jenkins_notifications"
+	}
 }
 
 /**
@@ -47,17 +47,17 @@ def getSlackChannel() {
  * @return the VCS commit hash of that build, or null if none could be found
  */
 def getLastSuccessfulCommit() {
-  def lastSuccessfulHash = null
-  def lastSuccessfulBuild = currentBuild.rawBuild.getPreviousSuccessfulBuild()
-  if ( lastSuccessfulBuild ) {
-    lastSuccessfulHash = commitHashForBuild( lastSuccessfulBuild )
-  } else {
-    lastSuccessfulBuild = currentBuild.rawBuild.getPreviousBuild() 
-    if (lastSuccessfulBuild) {
-        lastSuccessfulHash = commitHashForBuild( lastSuccessfulBuild )    
-    }   
-  }
-  return lastSuccessfulHash
+	def lastSuccessfulHash = null
+	def lastSuccessfulBuild = currentBuild.rawBuild.getPreviousSuccessfulBuild()
+	if ( lastSuccessfulBuild ) {
+		lastSuccessfulHash = commitHashForBuild( lastSuccessfulBuild )
+	} else {
+		lastSuccessfulBuild = currentBuild.rawBuild.getPreviousBuild()
+		if (lastSuccessfulBuild) {
+				lastSuccessfulHash = commitHashForBuild( lastSuccessfulBuild )
+		}
+	}
+	return lastSuccessfulHash
 }
 
 /**
@@ -73,12 +73,12 @@ def getLastSuccessfulCommit() {
  * @return a VCS commit hash, or null if none could be found
  */
 def commitHashForBuild( build ) {
-  def scmAction = build?.actions.find { action -> action instanceof jenkins.scm.api.SCMRevisionAction }
-  def revision = scmAction?.revision
-  if (revision instanceof org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision) {
-  	return revision?.pullHash
-  }
-  return revision?.hash
+	def scmAction = build?.actions.find { action -> action instanceof jenkins.scm.api.SCMRevisionAction }
+	def revision = scmAction?.revision
+	if (revision instanceof org.jenkinsci.plugins.github_branch_source.PullRequestSCMRevision) {
+		return revision?.pullHash
+	}
+	return revision?.hash
 }
 
 /**
@@ -97,7 +97,7 @@ def commitHashForBuild( build ) {
  */
 def getRepoUrl() {
 	def gituri = scm.repositories[0].uris[0].toASCIIString()
-    return gituri.replace(".git","").replace("git@github.com:","https://github.com/")
+	return gituri.replace(".git","").replace("git@github.com:","https://github.com/")
 }
 
 /**
@@ -113,11 +113,11 @@ def getRepoUrl() {
  * @see slack#commitHashForBuild
  */
 def getCurrentCommitLink() {
-    def currentCommit = commitHashForBuild( currentBuild.rawBuild )
-    def repoURL = getRepoUrl()
-    def commitURL = repoURL + "/commit/"
-    def shortHash = currentCommit[0..6]
-    return "(<${commitURL}${currentCommit}|${shortHash}>)"
+	def currentCommit = commitHashForBuild( currentBuild.rawBuild )
+	def repoURL = getRepoUrl()
+	def commitURL = repoURL + "/commit/"
+	def shortHash = currentCommit[0..6]
+	return "(<${commitURL}${currentCommit}|${shortHash}>)"
 }
 
 /**
@@ -142,25 +142,25 @@ def getCurrentCommitLink() {
  */
 def getCommitLog() {
 	def lastSuccessfulCommit = getLastSuccessfulCommit()
-    def currentCommit = commitHashForBuild( currentBuild.rawBuild )
-    def repoURL = getRepoUrl()
-    def commitURL = repoURL + "/commit/"
-    if (lastSuccessfulCommit) {
-        try {
-            commits = sh(
-                script: "git log --pretty=format:'- %s%b [%an] (<${commitURL}%H|%h>) %n' ${currentCommit} \"^${lastSuccessfulCommit}\"",
-                returnStdout: true
-            )
-            if (commits.equals("")) {
-        	    return "No Changes (re-build?)"
-            }
-        } catch (Throwable t) {
-            return "Couldn't get changes (history got changed?)"
-        }
-        
-       	return commits
-    }
-    return "No Changes (re-build?)"
+	def currentCommit = commitHashForBuild( currentBuild.rawBuild )
+	def repoURL = getRepoUrl()
+	def commitURL = repoURL + "/commit/"
+	if (lastSuccessfulCommit) {
+		try {
+			commits = sh(
+				script: "git log --pretty=format:'- %s%b [%an] (<${commitURL}%H|%h>) %n' ${currentCommit} \"^${lastSuccessfulCommit}\"",
+				returnStdout: true
+			)
+			if (commits.equals("")) {
+				return "No Changes (re-build?)"
+			}
+		} catch (Throwable t) {
+			return "Couldn't get changes (history got changed?)"
+		}
+
+		return commits
+	}
+	return "No Changes (re-build?)"
 }
 
 
@@ -189,23 +189,23 @@ def getCommitLog() {
  * @return a string containing the list of artifacts, or a message
  */
 def getArtifacts() { 
-    def summary = ""
-    try {
-	    def artifactStores = currentBuild.rawBuild.getAction(ArtifactStoreAction.class)
-	    if (artifactStores != null) {
-		    for(ArtifactStore artifact : artifactStores.artifacts) {
-			    def fileName = artifact.fileName
-			    def uuid = artifact.UDID
-			    summary += "<https://builds.fuzzhq.com/install.php?id=${uuid}|${fileName}>\n"
-		    }	    
-	    } else {
-		    summary = "No Artifacts"
-	    }
-    } catch (Throwable t) {
-	    println "Does not have Artifact Store Installed" 
-	    summary = "No Artifacts"
-    }
-    return summary
+	def summary = ""
+	try {
+		def artifactStores = currentBuild.rawBuild.getAction(ArtifactStoreAction.class)
+		if (artifactStores != null) {
+			for(ArtifactStore artifact : artifactStores.artifacts) {
+				def fileName = artifact.fileName
+				def uuid = artifact.UDID
+				summary += "<https://builds.fuzzhq.com/install.php?id=${uuid}|${fileName}>\n"
+			}
+		} else {
+			summary = "No Artifacts"
+		}
+	} catch (Throwable t) {
+		println "Does not have Artifact Store Installed"
+		summary = "No Artifacts"
+	}
+	return summary
 }
 
 /**
@@ -222,8 +222,8 @@ def getArtifacts() {
  * @see slack#getFailedTests
  */
 def hasTest() {
-    def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
-    return testResultAction != null
+	def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
+	return testResultAction != null
 }
 
 /**
@@ -251,35 +251,35 @@ def hasTest() {
  * @see slack#getFailedTests
  */
 def getTestSummary() {
-    def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
-    def summary = ""
+	def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
+	def summary = ""
 
-    if (testResultAction != null) {
-        orgtotal = testResultAction.getTotalCount()
-        orgfailed = testResultAction.getFailCount()
-        orgskipped = testResultAction.getSkipCount()
-	    
-        total = testResultAction.getTotalCount()
-        failed = testResultAction.getFailCount()
-        skipped = testResultAction.getSkipCount()
+	if (testResultAction != null) {
+		orgtotal = testResultAction.getTotalCount()
+		orgfailed = testResultAction.getFailCount()
+		orgskipped = testResultAction.getSkipCount()
 
-        if (env.SLACK_TEST_TOTAL && env.SLACK_TEST_TOTAL.toInteger() > 0) {
-            total = orgtotal - env.SLACK_TEST_TOTAL.toInteger()
-            failed = orgfailed - env.SLACK_TEST_FAILED.toInteger() 
-            skipped = orgskipped - env.SLACK_TEST_SKIPPED.toInteger()   
-        }
+		total = testResultAction.getTotalCount()
+		failed = testResultAction.getFailCount()
+		skipped = testResultAction.getSkipCount()
 
-        env.SLACK_TEST_TOTAL="${orgtotal}"
-        env.SLACK_TEST_FAILED="${orgfailed}"
-        env.SLACK_TEST_SKIPPED="${orgskipped}"
-	    
-        summary = "Passed: " + (total - failed - skipped)
-        summary = summary + (", Failed: " + failed)
-        summary = summary + (", Skipped: " + skipped)
-    } else {
-        summary = "No tests found"
-    }
-    return summary
+		if (env.SLACK_TEST_TOTAL && env.SLACK_TEST_TOTAL.toInteger() > 0) {
+			total = orgtotal - env.SLACK_TEST_TOTAL.toInteger()
+			failed = orgfailed - env.SLACK_TEST_FAILED.toInteger()
+			skipped = orgskipped - env.SLACK_TEST_SKIPPED.toInteger()
+		}
+
+		env.SLACK_TEST_TOTAL="${orgtotal}"
+		env.SLACK_TEST_FAILED="${orgfailed}"
+		env.SLACK_TEST_SKIPPED="${orgskipped}"
+
+		summary = "Passed: " + (total - failed - skipped)
+		summary = summary + (", Failed: " + failed)
+		summary = summary + (", Skipped: " + skipped)
+	} else {
+		summary = "No tests found"
+	}
+	return summary
 }
 
 /**
@@ -298,26 +298,26 @@ def getTestSummary() {
  * @see slack#getTestSummary
  */
 def getCoverageSummary() {
-    def coverageAction = currentBuild.rawBuild.getAction(CoberturaBuildAction.class)
-    def cloverCoverageAction = currentBuild.rawBuild.getAction(CloverBuildAction.class)
-    def summary = ""
+	def coverageAction = currentBuild.rawBuild.getAction(CoberturaBuildAction.class)
+	def cloverCoverageAction = currentBuild.rawBuild.getAction(CloverBuildAction.class)
+	def summary = ""
 
-    if (coverageAction != null) {
-        def lineData = coverageAction.getResult().getCoverage(CoverageMetric.LINE)
-        if (lineData != null) {
-        	summary = "Lines Covered: " + lineData.getPercentage() + "%"
-        } else {
-        	summary = "No Coverage Data"
-        }
-    } else if (cloverCoverageAction != null) {
-        def coverageData = cloverCoverageAction.getResult()
-        if (coverageData != null) {
-            summary = "Lines Covered: " + coverageData.getStatementCoverage().getPercentageStr()
-        }
-    } else {
-        summary = "No Coverage Data"
-    }
-    return summary
+	if (coverageAction != null) {
+		def lineData = coverageAction.getResult().getCoverage(CoverageMetric.LINE)
+		if (lineData != null) {
+			summary = "Lines Covered: " + lineData.getPercentage() + "%"
+		} else {
+			summary = "No Coverage Data"
+		}
+	} else if (cloverCoverageAction != null) {
+		def coverageData = cloverCoverageAction.getResult()
+		if (coverageData != null) {
+			summary = "Lines Covered: " + coverageData.getStatementCoverage().getPercentageStr()
+		}
+	} else {
+		summary = "No Coverage Data"
+	}
+	return summary
 }
 
 /**
@@ -339,31 +339,31 @@ def getCoverageSummary() {
  * @see slack#sendSlackError
  */
 def getFailedTests() {
-    def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
-    if (testResultAction != null) {
-    	def failedTestsString = ""
-        def failedTests = testResultAction.getFailedTests()
+	def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
+	if (testResultAction != null) {
+		def failedTestsString = ""
+		def failedTests = testResultAction.getFailedTests()
 
-        if (failedTests.size() > 9) {
-            failedTests = failedTests.subList(0, 8)
-        }
+		if (failedTests.size() > 9) {
+			failedTests = failedTests.subList(0, 8)
+		}
 
-        for(CaseResult cr : failedTests) {
-            if (cr.getFullDisplayName().contains("${env.STAGE_NAME} / ")) {
-                testDisplayName = cr.getFullDisplayName().replace("${env.STAGE_NAME} / ", "")
-                failedTestsString = failedTestsString + "${testDisplayName}:\n${cr.getErrorDetails()}\n\n"
-            } else if (!cr.getFullDisplayName().contains(" / ")) {
-                failedTestsString = failedTestsString + "${cr.getFullDisplayName()}:\n${cr.getErrorDetails()}\n\n"
-            }
-        }
-        if (failedTestsString.equals("")) {
-        	return null;
-        } else {
-        	return "```" + failedTestsString + "```"
-        }
-    } else {
-    	return null
-    }
+		for(CaseResult cr : failedTests) {
+			if (cr.getFullDisplayName().contains("${env.STAGE_NAME} / ")) {
+				testDisplayName = cr.getFullDisplayName().replace("${env.STAGE_NAME} / ", "")
+				failedTestsString = failedTestsString + "${testDisplayName}:\n${cr.getErrorDetails()}\n\n"
+			} else if (!cr.getFullDisplayName().contains(" / ")) {
+				failedTestsString = failedTestsString + "${cr.getFullDisplayName()}:\n${cr.getErrorDetails()}\n\n"
+			}
+		}
+		if (failedTestsString.equals("")) {
+			return null;
+		} else {
+			return "```" + failedTestsString + "```"
+		}
+	} else {
+		return null
+	}
 }
 
 /**
@@ -400,12 +400,12 @@ def qsh(command) {
  * @see slack#qsh
  */
 def qbash(command) {
-    try {
-        bash command  
-    } catch (Exception e) {
-        sendSlackError(e, "Failed to ${command} in _*Stage ${env.STAGE_NAME}*_")
-        throw e
-    }
+	try {
+		bash command
+	} catch (Exception e) {
+		sendSlackError(e, "Failed to ${command} in _*Stage ${env.STAGE_NAME}*_")
+		throw e
+	}
 }
 
 /**
@@ -441,12 +441,12 @@ def wrap(command, errorMessage) {
 def jobName() {
 	def job = "${env.JOB_NAME}"
 	def splits = job.split("/")
-    if (splits.length > 1) {
-	   def jobName = splits[splits.length - 2] + "/" + splits[splits.length - 1]
-	   return jobName
-    } else {
-        return job;
-    }
+	if (splits.length > 1) {
+		def jobName = splits[splits.length - 2] + "/" + splits[splits.length - 1]
+		return jobName
+	} else {
+		return job;
+	}
 }
 
 /**
@@ -500,7 +500,7 @@ def slackHeader() {
 	def slackHeader = "${jobName} - #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)\n"
 	def currentCommitLink = getCurrentCommitLink()
 	if (isPR()) {
-        slackHeader += "Branch _*${env.CHANGE_BRANCH}*_ ${currentCommitLink}\n"
+		slackHeader += "Branch _*${env.CHANGE_BRANCH}*_ ${currentCommitLink}\n"
 		slackHeader += PRMessage()
 	} else {
 		slackHeader += "Branch _*${env.BRANCH_NAME}*_ ${currentCommitLink}\n"
@@ -527,39 +527,39 @@ def slackHeader() {
  * @return nothing
  */
 def sendSlackError(Exception e, String message) {
-    def errorMessage = e.toString()
-    if (!(e instanceof InterruptedException) && env.SLACK_CHANNEL_NOTIFIED != "true" && !errorMessage.contains("Queue task was cancelled")) {
-        env.SLACK_CHANNEL_NOTIFIED = "true"
-        def logs = currentBuild.rawBuild.getLog(200).reverse()
-        def logsToPrint = []
-        def addToLogs = true
-        for(String logString : logs) {
-            if (logString.contains("from /Users")) { //iOS Ruby Exceptions
-            } else if (logString.contains("/lib/rails/") || logString.contains("/.rvm/gems/ruby")) { //iOS Ruby Exceptions
-            } else if(logString.contains("fastlane finished with errors")) {
-                if (logsToPrint.size() > 0) {
-                    addToLogs = false    
-                }
-            } else if(logString.contains("[Pipeline]")) { //Jenkins Pipeline Info
-                if (logsToPrint.size() > 0) {
-                    addToLogs = false    
-                }
-            } else if (logString.contains("at ") && (logString.contains(".java") || logString.contains(".kt") || logString.contains(".groovy"))) { //Gradle Exceptions
-            } else if (logString.contains("FAILURE: Build failed with an exception")) {
-                if (logsToPrint.size() > 0) {
-                    addToLogs = false    
-                }
-            } else {
-                if (addToLogs) {
-                    logsToPrint.add(logString)
-                }
-            }
-        } 
-        logsToPrint = logsToPrint.reverse()
-        logsString = logsToPrint.subList(Math.max(logsToPrint.size() - 20, 0), logsToPrint.size()).join("\n")
+	def errorMessage = e.toString()
+	if (!(e instanceof InterruptedException) && env.SLACK_CHANNEL_NOTIFIED != "true" && !errorMessage.contains("Queue task was cancelled")) {
+		env.SLACK_CHANNEL_NOTIFIED = "true"
+		def logs = currentBuild.rawBuild.getLog(200).reverse()
+		def logsToPrint = []
+		def addToLogs = true
+		for(String logString : logs) {
+			if (logString.contains("from /Users")) { //iOS Ruby Exceptions
+			} else if (logString.contains("/lib/rails/") || logString.contains("/.rvm/gems/ruby")) { //iOS Ruby Exceptions
+			} else if(logString.contains("fastlane finished with errors")) {
+				if (logsToPrint.size() > 0) {
+					addToLogs = false
+				}
+			} else if(logString.contains("[Pipeline]")) { //Jenkins Pipeline Info
+				if (logsToPrint.size() > 0) {
+					addToLogs = false
+				}
+			} else if (logString.contains("at ") && (logString.contains(".java") || logString.contains(".kt") || logString.contains(".groovy"))) { //Gradle Exceptions
+			} else if (logString.contains("FAILURE: Build failed with an exception")) {
+				if (logsToPrint.size() > 0) {
+					addToLogs = false
+				}
+			} else {
+				if (addToLogs) {
+					logsToPrint.add(logString)
+				}
+			}
+		}
+		logsToPrint = logsToPrint.reverse()
+		logsString = logsToPrint.subList(Math.max(logsToPrint.size() - 20, 0), logsToPrint.size()).join("\n")
 
-        // Local variable representing the response from Slack's API.
-        def slackResponse = null
+		// Local variable representing the response from Slack's API.
+		def slackResponse = null
 
 		echo "About to send header to the main channel..."
 		slackResponse = slackSend color: 'danger', channel: slackChannel, message: slackHeader() + message
@@ -574,8 +574,8 @@ def sendSlackError(Exception e, String message) {
 			echo "...and making two additional notes elsewhere."
 			slackResponse = slackSend color: 'danger', channel: "jenkins_notifications", message: slackHeader() + "${e}"
 			slackSend color: 'danger', channel: slackResponse.threadId, message: e.printStackTrace()
-        }
-    }
+		}
+	}
 }
 
 def sendMessageWithLogs(String message) {
@@ -694,14 +694,14 @@ def testMessage() {
  * @return false if there were test failures, true otherwise
  */
 def isProjectSuccessful() {
-    def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
-    projectSuccessful = true
-    if (testResultAction != null) {
-        if (testResultAction.getFailCount() > 0) {
-            projectSuccessful = false  
-        }
-    }
-    return projectSuccessful;
+	def testResultAction = currentBuild.rawBuild.getAction(TestResultAction.class)
+	projectSuccessful = true
+	if (testResultAction != null) {
+		if (testResultAction.getFailCount() > 0) {
+			projectSuccessful = false
+		}
+	}
+	return projectSuccessful;
 }
 
 /**
@@ -724,24 +724,24 @@ def isProjectSuccessful() {
  * @see uatStage#call
  */
 def uatMessage() {
-    def slackHeader = slackHeader() + "\n*Stage*: ${env.STAGE_NAME}\n"
-    def failedTest = getFailedTests()
-    def testSummary = "_*Test Results*_\n" + getTestSummary() + "\n"
-    def reportMessage = "_*Report*_\n" + env.JOB_URL + "Extent-Report/" + "\n"
-    if (env.TEST_RAIL_ID) {
-        def testRailURL = "https://fuzz.testrail.io/index.php?/runs/overview/${env.TEST_RAIL_ID}" 
-    }
-    def slackTestSummary = testSummary + reportMessage
-    if (failedTest == null) {
-        if (testSummary.contains("No tests found")) {
-            slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary 
-        } else {
-            slackSend color: 'good', channel: slackChannel, message: slackHeader + slackTestSummary 
-        }
-    } else {
-        slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
-        slackSend color: 'warning', channel: slackChannel, message: failedTest
-    }
+	def slackHeader = slackHeader() + "\n*Stage*: ${env.STAGE_NAME}\n"
+	def failedTest = getFailedTests()
+	def testSummary = "_*Test Results*_\n" + getTestSummary() + "\n"
+	def reportMessage = "_*Report*_\n" + env.JOB_URL + "Extent-Report/" + "\n"
+	if (env.TEST_RAIL_ID) {
+		def testRailURL = "https://fuzz.testrail.io/index.php?/runs/overview/${env.TEST_RAIL_ID}"
+	}
+	def slackTestSummary = testSummary + reportMessage
+	if (failedTest == null) {
+		if (testSummary.contains("No tests found")) {
+			slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
+		} else {
+			slackSend color: 'good', channel: slackChannel, message: slackHeader + slackTestSummary
+		}
+	} else {
+		slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
+		slackSend color: 'warning', channel: slackChannel, message: failedTest
+	}
 }
 
 /**

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -218,7 +218,14 @@ def getCommitLog() {
 			return "Couldn't get changes (history got changed?)"
 		}
 
-		return commits
+		// If we get here, there is at least one commit in the given range
+		int commitCount = sh(
+			script: "git rev-list --count \"^${lastSuccessfulCommit}\" ${currentCommit} | tr -d '\n'",
+			returnStdout: true
+		) as int
+
+		// If your workspace has a git emoji, we try to use it here
+		return ":git: commit count: ${commitCount}.\n ${commits}"
 	}
 	return "No Changes (re-build?)"
 }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -20,6 +20,7 @@ class slack {
  */
 static SlackResponse threadAnchor = null
 
+}
 
 /**
  * Get the name of the current build's Slack channel.
@@ -903,6 +904,4 @@ def uatMessage() {
 def echo() {
 	def header = slackHeader()
 	slackSend color: 'good', channel: slackChannel, message: header
-}
-
 }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -9,6 +9,11 @@ import jenkins.plugins.slack.workflow.SlackResponse
 
 
 /**
+ * Use the methods here to communicate with an instance of <a href="https://slack.com/">Slack</a>.
+ */
+class slack {
+
+/**
  * A 'SlackResponse' object representing the header of a thread of messages.
  *
  * @see slack#ensureThreadAnchor
@@ -898,4 +903,6 @@ def uatMessage() {
 def echo() {
 	def header = slackHeader()
 	slackSend color: 'good', channel: slackChannel, message: header
+}
+
 }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -7,6 +7,13 @@ import hudson.tasks.junit.CaseResult
 import hudson.tasks.junit.TestResultAction
 
 
+/**
+ * A 'SlackResponse' object representing the header of a thread of messages.
+ *
+ * @see slack#ensureThreadAnchor
+ */
+def threadAnchor = null
+
 
 /**
  * Get the name of the current build's Slack channel.
@@ -72,8 +79,8 @@ private void ensureThreadAnchor() {
 
 		// Local variable representing the response from Slack's API.
 		def slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader
-		// We keep around the original response as a header, so that we can attach emoji.
-		env.SLACK_THREAD_HEADER = slackResponse
+		// We keep around the original response to this, so that we can attach emoji.
+		threadAnchor = slackResponse
 		env.SLACK_THREAD_ID = slackResponse.threadId
 	}
 }
@@ -649,7 +656,7 @@ def sendSlackError(Exception e, String message) {
 		ensureThreadAnchor()
 
 		// Attach a warning emoji to the thread anchor
-		env.SLACK_THREAD_HEADER.addReaction("warning")
+		threadAnchor.addReaction("warning")
 
 		// Local variable representing the response from Slack's API.
 		//noinspection GroovyUnusedAssignment

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -5,6 +5,7 @@ import hudson.plugins.cobertura.CoberturaBuildAction
 import hudson.plugins.cobertura.targets.CoverageMetric
 import hudson.tasks.junit.CaseResult
 import hudson.tasks.junit.TestResultAction
+import jenkins.plugins.slack.workflow.SlackResponse
 
 
 /**
@@ -12,7 +13,7 @@ import hudson.tasks.junit.TestResultAction
  *
  * @see slack#ensureThreadAnchor
  */
-def threadAnchor = null
+static SlackResponse threadAnchor = null
 
 
 /**

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -586,9 +586,13 @@ def sendSlackError(Exception e, String message) {
 
 def sendMessageWithLogs(String message) {
 	def logs = currentBuild.rawBuild.getLog(10).reverse()
-        logsString = logs.reverse().subList(1, logs.size()).join("\n")
-        slackSend color: 'warning', channel: slackChannel, message:message
-        slackSend color: 'warning', channel: slackChannel, message:"```${logsString}```"
+	logsString = logs.reverse().subList(1, logs.size()).join("\n")
+
+	// Local variable representing the response from Slack's API.
+	def slackResponse = null
+
+	slackResponse = slackSend color: 'warning', channel: slackChannel, message:message
+	slackSend color: 'warning', channel: slackResponse.threadId, message:"```${logsString}```"
 }
 
 /**
@@ -611,9 +615,13 @@ def buildMessage() {
 	def jobName = jobName()
 	def slackHeader = slackHeader()
 	def slackArtifacts = getArtifacts()
-	slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
+
+	// Local variable representing the response from Slack's API.
+	def slackResponse = null
+
+	slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
 	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-	slackSend color: 'good', channel: slackChannel, message: commitLogHeader + getCommitLog()
+	slackSend color: 'good', channel: slackResponse.threadId, message: commitLogHeader + getCommitLog()
 }
 
 
@@ -635,12 +643,16 @@ def buildMessage() {
  * @see slack#uatMessage
  */
 def linkMessage(String inURL) {
-    def jobName = jobName()
-    def slackHeader = slackHeader()
-    def slackArtifacts = "${inURL}\n"
-    slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
-    def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-    slackSend color: 'good', channel: slackChannel, message: commitLogHeader + getCommitLog()
+	def jobName = jobName()
+	def slackHeader = slackHeader()
+	def slackArtifacts = "${inURL}\n"
+
+	// Local variable representing the response from Slack's API.
+	def slackResponse = null
+
+	slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
+	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
+	slackSend color: 'good', channel: slackResponse.threadId, message: commitLogHeader + getCommitLog()
 }
 
 /**

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -567,13 +567,17 @@ def sendSlackError(Exception e, String message) {
         // Local variable representing the response from Slack's API.
         def slackResponse = null
 
-        slackResponse = slackSend color: 'danger', channel: slackChannel, message: slackHeader() + message
-        slackSend color: 'danger', channel: slackResponse.threadId, message:"```${logsString}```"
+		echo "About to send header to the main channel..."
+		slackResponse = slackSend color: 'danger', channel: slackChannel, message: slackHeader() + message
+		echo "...and now trying to add details to that, in the new thread with id " + slackResponse.threadId
+		slackSend color: 'danger', channel: slackResponse.threadId, message:"```${logsString}```"
 
-        if (!errorMessage.contains("script returned exit code 1")) {
+		if (!errorMessage.contains("script returned exit code 1")) {
 			// Attach a warning emoji to the existing message...
+			echo "Attaching a response to the header message..."
 			slackResponse.addReaction("warning")
 			// ...and send a stacktrace to the DevOps monitoring channel
+			echo "...and making two additional notes elsewhere."
 			slackResponse = slackSend color: 'danger', channel: "jenkins_notifications", message: slackHeader() + "${e}"
 			slackSend color: 'danger', channel: slackResponse.threadId, message: e.printStackTrace()
         }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -208,7 +208,7 @@ def getCommitLog() {
 	if (lastSuccessfulCommit) {
 		try {
 			commits = sh(
-				script: "git log --pretty=format:'- %s%b [%an] (<${commitURL}%H|%h>) %n' ${currentCommit} \"^${lastSuccessfulCommit}\"",
+				script: "git log --pretty=format:'- %s%b [%an] (<${commitURL}%h|%h>) %n' ${currentCommit} \"^${lastSuccessfulCommit}\"",
 				returnStdout: true
 			)
 			if (commits.equals("")) {

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -1,18 +1,12 @@
-import groovy.json.JsonSlurperClassic
-import java.lang.InterruptedException
-import groovy.json.JsonOutput
-import java.util.Optional
-import hudson.tasks.junit.TestResultAction
-import hudson.model.Actionable
-import hudson.tasks.junit.CaseResult
-import com.fuzz.artifactstore.ArtifactStoreAction
 import com.fuzz.artifactstore.ArtifactStore
+import com.fuzz.artifactstore.ArtifactStoreAction
+import hudson.plugins.clover.CloverBuildAction
 import hudson.plugins.cobertura.CoberturaBuildAction
 import hudson.plugins.cobertura.targets.CoverageMetric
-import hudson.plugins.clover.CloverBuildAction
-import hudson.plugins.clover.results.ProjectCoverage
-import hudson.plugins.clover.Ratio
-import groovy.transform.Field
+import hudson.tasks.junit.CaseResult
+import hudson.tasks.junit.TestResultAction
+
+
 
 /**
  * Get the name of the current build's Slack channel.

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -9,9 +9,9 @@ import jenkins.plugins.slack.workflow.SlackResponse
 
 
 /**
- * Use the methods here to communicate with an instance of <a href="https://slack.com/">Slack</a>.
+ * Companion class to {@link slack#call}.
  */
-class slack {
+class slackExtras {
 
 /**
  * A 'SlackResponse' object representing the header of a thread of messages.
@@ -20,6 +20,14 @@ class slack {
  */
 static SlackResponse threadAnchor = null
 
+}
+
+/**
+ * Use the methods on this class to communicate with an instance of <a href="https://slack.com/">Slack</a>.
+ *
+ * Note that this method, in particular, does nothing.
+ */
+void call() {
 }
 
 /**
@@ -69,7 +77,7 @@ def getSlackThread() {
 /**
  * Internal method, intended for use by anything calling <code>slackSend</code>.
  * <p>
- *     If env.SLACK_THREAD_ID and {@link slack#threadAnchor} are defined, this
+ *     If env.SLACK_THREAD_ID and {@link slackExtras#threadAnchor} are defined, this
  *     returns immediately.
  * </p>
  * <p>
@@ -82,13 +90,13 @@ def getSlackThread() {
  * @see slack#slackHeader()
  */
 private void ensureThreadAnchor() {
-	if (!env.SLACK_THREAD_ID || threadAnchor == null) {
+	if (!env.SLACK_THREAD_ID || slackExtras.threadAnchor == null) {
 		def slackHeader = slackHeader()
 
 		// Local variable representing the response from Slack's API.
 		def slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader
 		// We keep around the original response to this, so that we can attach emoji.
-		threadAnchor = slackResponse
+		slackExtras.threadAnchor = slackResponse
 		env.SLACK_THREAD_ID = slackResponse.threadId
 	}
 }
@@ -671,7 +679,7 @@ def sendSlackError(Exception e, String message) {
 		ensureThreadAnchor()
 
 		// Attach a warning emoji to the thread anchor
-		threadAnchor.addReaction("warning")
+		slackExtras.threadAnchor.addReaction("warning")
 
 		// Local variable representing the response from Slack's API.
 		//noinspection GroovyUnusedAssignment

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -563,12 +563,19 @@ def sendSlackError(Exception e, String message) {
         } 
         logsToPrint = logsToPrint.reverse()
         logsString = logsToPrint.subList(Math.max(logsToPrint.size() - 20, 0), logsToPrint.size()).join("\n")
-        slackSend color: 'danger', channel: slackChannel, message:slackHeader() + message
-        slackSend color: 'danger', channel: slackChannel, message:"```${logsString}```"
+
+        // Local variable representing the response from Slack's API.
+        def slackResponse = null
+
+        slackResponse = slackSend color: 'danger', channel: slackChannel, message: slackHeader() + message
+        slackSend color: 'danger', channel: slackResponse.threadId, message:"```${logsString}```"
 
         if (!errorMessage.contains("script returned exit code 1")) {
-           slackSend color: 'danger', channel: "jenkins_notifications", message:slackHeader() + "${e}" 
-	   slackSend color: 'danger', channel: "jenkins_notifications", message:e.printStackTrace()  
+			// Attach a warning emoji to the existing message...
+			slackResponse.addReaction("warning")
+			// ...and send a stacktrace to the DevOps monitoring channel
+			slackResponse = slackSend color: 'danger', channel: "jenkins_notifications", message: slackHeader() + "${e}"
+			slackSend color: 'danger', channel: slackResponse.threadId, message: e.printStackTrace()
         }
     }
 }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -655,11 +655,10 @@ def sendMessageWithLogs(String message) {
 	def logs = currentBuild.rawBuild.getLog(10).reverse()
 	logsString = logs.reverse().subList(1, logs.size()).join("\n")
 
-	// Local variable representing the response from Slack's API.
-	def slackResponse = null
+	ensureThreadAnchor()
 
-	slackResponse = slackSend color: 'warning', channel: slackChannel, message:message
-	slackSend color: 'warning', channel: slackResponse.threadId, message:"```${logsString}```"
+	slackSend color: 'warning', channel: slackThread, message:message
+	slackSend color: 'warning', channel: slackThread, message:"```${logsString}```"
 }
 
 /**
@@ -673,7 +672,7 @@ def sendMessageWithLogs(String message) {
  *     <li>{@link slack#getCommitLog List of commit messages}</li>
  * </ul>
  *
- * @return a newline-separated string, as described above
+ * @return nothing
  * @see slack#linkMessage
  * @see slack#testMessage
  * @see slack#uatMessage
@@ -683,12 +682,11 @@ def buildMessage() {
 	def slackHeader = slackHeader()
 	def slackArtifacts = getArtifacts()
 
-	// Local variable representing the response from Slack's API.
-	def slackResponse = null
+	ensureThreadAnchor()
 
-	slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
+	slackSend color: 'good', channel: slackThread, message: slackHeader + slackArtifacts
 	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-	slackSend color: 'good', channel: slackResponse.threadId, message: commitLogHeader + getCommitLog()
+	slackSend color: 'good', channel: slackThread, message: commitLogHeader + getCommitLog()
 }
 
 
@@ -704,7 +702,7 @@ def buildMessage() {
  * </ul>
  *
  * @param inURL http or https url for the deployed website
- * @return a newline-separated string, as described above
+ * @return nothing
  * @see slack#buildMessage
  * @see slack#testMessage
  * @see slack#uatMessage
@@ -714,12 +712,11 @@ def linkMessage(String inURL) {
 	def slackHeader = slackHeader()
 	def slackArtifacts = "${inURL}\n"
 
-	// Local variable representing the response from Slack's API.
-	def slackResponse = null
+	ensureThreadAnchor()
 
-	slackResponse = slackSend color: 'good', channel: slackChannel, message: slackHeader + slackArtifacts
+	slackSend color: 'good', channel: slackThread, message: slackHeader + slackArtifacts
 	def commitLogHeader = "${jobName} - #${env.BUILD_NUMBER} <${env.BUILD_URL}/changes|Changes>:\n"
-	slackSend color: 'good', channel: slackResponse.threadId, message: commitLogHeader + getCommitLog()
+	slackSend color: 'good', channel: slackThread, message: commitLogHeader + getCommitLog()
 }
 
 /**
@@ -735,7 +732,7 @@ def linkMessage(String inURL) {
  *     truly without associated tests should not be using {@link testStage}.
  * </p>
  *
- * @return a newline-separated string, as described above
+ * @return nothing
  * @see slack#buildMessage
  * @see slack#linkMessage
  * @see slack#uatMessage
@@ -746,15 +743,18 @@ def testMessage() {
 	def testSummary = "_*Test Results*_\n" + getTestSummary() + "\n"
 	def coverageSummary = "_*Code Coverage*_\n" + getCoverageSummary() + "\n"
 	def slackTestSummary = testSummary + coverageSummary
+
+	ensureThreadAnchor()
+
 	if (failedTest == null) {
 		if (testSummary.contains("No tests found")) {
-			slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary 
+			slackSend color: 'warning', channel: slackThread, message: slackHeader + slackTestSummary
 		} else {
-			slackSend color: 'good', channel: slackChannel, message: slackHeader + slackTestSummary 
+			slackSend color: 'good', channel: slackThread, message: slackHeader + slackTestSummary
 		}
 	} else {
-		slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
-		slackSend color: 'warning', channel: slackChannel, message: failedTest
+		slackSend color: 'warning', channel: slackThread, message: slackHeader + slackTestSummary
+		slackSend color: 'warning', channel: slackThread, message: failedTest
 	}
 }
 
@@ -805,15 +805,18 @@ def uatMessage() {
 		def testRailURL = "https://fuzz.testrail.io/index.php?/runs/overview/${env.TEST_RAIL_ID}"
 	}
 	def slackTestSummary = testSummary + reportMessage
+
+	ensureThreadAnchor()
+
 	if (failedTest == null) {
 		if (testSummary.contains("No tests found")) {
-			slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
+			slackSend color: 'warning', channel: slackThread, message: slackHeader + slackTestSummary
 		} else {
-			slackSend color: 'good', channel: slackChannel, message: slackHeader + slackTestSummary
+			slackSend color: 'good', channel: slackThread, message: slackHeader + slackTestSummary
 		}
 	} else {
-		slackSend color: 'warning', channel: slackChannel, message: slackHeader + slackTestSummary
-		slackSend color: 'warning', channel: slackChannel, message: failedTest
+		slackSend color: 'warning', channel: slackThread, message: slackHeader + slackTestSummary
+		slackSend color: 'warning', channel: slackThread, message: failedTest
 	}
 }
 

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -75,10 +75,19 @@ def getSlackThread() {
 }
 
 /**
- * Internal method, intended for use by anything calling <code>slackSend</code>.
+ * Quick setup method for new pipelines.
  * <p>
- *     If env.SLACK_THREAD_ID and {@link slackExtras#threadAnchor} are defined, this
- *     returns immediately.
+ *     Most of the time, scripts won't need to use this directly. All
+ *     of the methods in this class that call <code>slackSend</code>
+ *     use this to make sure they're running in a sane environment.
+ * </p>
+ * <p>
+ *     For convenience, this method is aliased to {@link slack#echo}
+ *     and its alternative variant {@link slackEcho#call}.
+ * </p>
+ * <p>
+ *     If env.SLACK_THREAD_ID and {@link slackExtras#threadAnchor} are
+ *     defined, this returns immediately.
  * </p>
  * <p>
  *     Otherwise, this sends a very simple 'anchor' message to the
@@ -89,7 +98,7 @@ def getSlackThread() {
  * @see slack#getSlackThread()
  * @see slack#slackHeader()
  */
-private void ensureThreadAnchor() {
+void ensureThreadAnchor() {
 	if (!env.SLACK_THREAD_ID || slackExtras.threadAnchor == null) {
 		def slackHeader = slackHeader()
 
@@ -908,8 +917,8 @@ def uatMessage() {
  *
  * @return nothing
  * @see slack#getSlackChannel()
+ * @see slack#ensureThreadAnchor()
  */
 def echo() {
-	def header = slackHeader()
-	slackSend color: 'good', channel: slackChannel, message: header
+	ensureThreadAnchor()
 }

--- a/vars/slack.groovy
+++ b/vars/slack.groovy
@@ -62,7 +62,8 @@ def getSlackThread() {
 /**
  * Internal method, intended for use by anything calling <code>slackSend</code>.
  * <p>
- *     If env.SLACK_THREAD_ID is defined, this returns immediately.
+ *     If env.SLACK_THREAD_ID and {@link slack#threadAnchor} are defined, this
+ *     returns immediately.
  * </p>
  * <p>
  *     Otherwise, this sends a very simple 'anchor' message to the
@@ -74,7 +75,7 @@ def getSlackThread() {
  * @see slack#slackHeader()
  */
 private void ensureThreadAnchor() {
-	if (!env.SLACK_THREAD_ID) {
+	if (!env.SLACK_THREAD_ID || threadAnchor == null) {
 		def slackHeader = slackHeader()
 
 		// Local variable representing the response from Slack's API.


### PR DESCRIPTION
This adds additional commands to the 'sendSlack()' calls in vars/slack.groovy. We will now attempt to
1. Place error stacktraces into a thread under the initial error message
2. Place 'git log' output into a thread under the initial header
3. Attach a :warning: emoji reaction to any per-channel error that is affected by groovy execution (e.g. attempted usage of forbidden APIs, typos in command names, incorrect arguments)
4. Describe the quantity of new git commits in 'changelog' messages, in case the message is cut off

Note that we now ask for the 'bot user' option to be enabled, which is **incompatible** with the legacy Slack-owned app. Please refer to the guide at https://github.com/jenkinsci/slack-plugin/#bot-user-mode for assistance in creating a new Slack app with 'bot user'-mode enabled.